### PR TITLE
Fix dependency problem

### DIFF
--- a/core.php
+++ b/core.php
@@ -209,6 +209,7 @@ class Core {
 	public function kill_heartbeat() {
 		do_action( 'hbc_before_kill_heartbeat' );
 		wp_deregister_script( 'heartbeat' );
+		wp_register_script( 'heartbeat', null );
 		do_action( 'hbc_after_kill_heartbeat' );
 	}
 


### PR DESCRIPTION
Hi :)

If you remove completely heartbeat dependency, this will causes issues. Not visible most of the time but it will noticed by debug plugins like query monitor (big red alert).

Example : https://wordpress.org/support/topic/suppress-presistent-errors-ex-broken-dependencies-wp-auth-check-on-wp-engine/

So, the heartbeat script should be replaced like i make it in my pull request

Apparently it's work with `null` value (depency is respected and no js file is injected) but if there is a problem, it may be necessary to use a empty javascript file.

